### PR TITLE
Initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,131 @@
 # @serverless/tencent-koa
+
+Easily deploy [koa](https://koajs.com/) applications to Tencent Cloud's serverless infrastructure using this Serverless Framework Component. Your application will auto-scale, never charge you for idle time, and require little-to-zero administration.
+
+&nbsp;
+
+1. [Install](#1-install)
+2. [Create](#2-create)
+3. [Configure](#3-configure)
+4. [Deploy](#4-deploy)
+5. [Remove](#5-remove)
+
+&nbsp;
+
+&nbsp;
+
+### 1. Install
+
+```console
+$ npm install -g serverless
+```
+
+### 2. Create
+
+Just create `serverless.yml` and `.env` files
+
+```console
+$ touch .env # your Tencent API Keys
+$ touch app.js
+$ touch serverless.yml
+```
+
+Add the access keys of a [Tencent CAM Role](https://console.cloud.tencent.com/cam/capi) with `AdministratorAccess` in the `.env` file, using this format:
+
+```
+# .env
+TENCENT_SECRET_ID=123
+TENCENT_SECRET_KEY=123
+```
+
+- If you don't have a Tencent Cloud account, you could [sign up](https://intl.cloud.tencent.com/register) first.
+
+Initialize a new NPM package and install koa:
+
+```
+npm init          # then keep hitting enter
+npm i --save koa  # install koa
+```
+
+create your koa app in `app.js`:
+
+```js
+const koa = require('koa');
+const app = koa();
+
+app.use(async (ctx, next) => {
+  if (ctx.path !== '/') return next();
+  ctx.body = 'Hello from Koa';
+});
+
+// don't forget to export!
+module.exports = app;
+```
+
+### 3. Configure
+
+```yml
+# serverless.yml
+
+koa:
+  component: '@serverless/tencent-koa'
+  inputs:
+    region: ap-shanghai
+```
+
+- [Click here to view the configuration document](https://github.com/serverless-tencent/tencent-koa/blob/master/docs/configure.md)
+
+### 4. Deploy
+
+```
+$ sls --debug
+
+  DEBUG ─ Resolving the template's static variables.
+  DEBUG ─ Collecting components from the template.
+  DEBUG ─ Downloading any NPM components found in the template.
+  DEBUG ─ Analyzing the template's components dependencies.
+  DEBUG ─ Creating the template's components graph.
+  DEBUG ─ Syncing template state.
+  DEBUG ─ Executing the template's components graph.
+  DEBUG ─ Compressing function KoaComponent_7xRrrd file to /Users/dfounderliu/Desktop/temp/code/.serverless/KoaComponent_7xRrrd.zip.
+  DEBUG ─ Compressed function KoaComponent_7xRrrd file successful
+  DEBUG ─ Uploading service package to cos[sls-cloudfunction-ap-shanghai-code]. sls-cloudfunction-default-KoaComponent_7xRrrd-1572512568.zip
+  DEBUG ─ Uploaded package successful /Users/dfounderliu/Desktop/temp/code/.serverless/KoaComponent_7xRrrd.zip
+  DEBUG ─ Creating function KoaComponent_7xRrrd
+  DEBUG ─ Created function KoaComponent_7xRrrd successful
+  DEBUG ─ Starting API-Gateway deployment with name koa.TencentApiGateway in the ap-shanghai region
+  DEBUG ─ Using last time deploy service id service-n0vs2ohb
+  DEBUG ─ Updating service with serviceId service-n0vs2ohb.
+  DEBUG ─ Endpoint ANY / already exists with id api-9z60urs4.
+  DEBUG ─ Updating api with api id api-9z60urs4.
+  DEBUG ─ Service with id api-9z60urs4 updated.
+  DEBUG ─ Deploying service with id service-n0vs2ohb.
+  DEBUG ─ Deployment successful for the api named koa.TencentApiGateway in the ap-shanghai region.
+
+  koa:
+    region:              ap-shanghai
+    functionName:        KoaComponent_7xRrrd
+    apiGatewayServiceId: service-n0vs2ohb
+    url:                 http://service-n0vs2ohb-1300415943.ap-shanghai.apigateway.myqcloud.com/release/
+
+  36s › koa › done
+```
+
+You can now visit the output URL in the browser, and you should see the koa response.
+
+### 5. Remove
+
+```
+$ sls remove --debug
+
+  DEBUG ─ Flushing template state and removing all components.
+  DEBUG ─ Removed function KoaComponent_MHrAzr successful
+  DEBUG ─ Removing any previously deployed API. api-kf2hxrhc
+  DEBUG ─ Removing any previously deployed service. service-4ndfl6pz
+
+  13s › koa › done
+```
+
+### New to Components?
+
+Checkout the [Serverless Components](https://github.com/serverless/components) repo for more information.

--- a/lambda-handler.js
+++ b/lambda-handler.js
@@ -1,0 +1,11 @@
+// To be included with user lambda (in bundled form)
+
+'use strict';
+
+const { createServer, proxy } = require('aws-serverless-express');
+
+const server = createServer(require.fromParentEnvironment('./app').callback());
+
+module.exports.handler = (event, context) => {
+  return proxy(server, event, context, 'PROMISE').promise;
+};

--- a/lib/resolve-cached-handler-path/generate.js
+++ b/lib/resolve-cached-handler-path/generate.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+const fse = require('fs-extra');
+const webmake = require('webmake');
+const Terser = require('terser');
+const resolvePath = require('./resolve-path');
+
+const handlerModulePath = path.join(__dirname, '../../lambda-handler.js');
+
+module.exports = async ({ lambdaHandlerMode }) => {
+  const cachedHandlerPath = resolvePath({ lambdaHandlerMode });
+  let bundleCode = await new Promise((resolve, reject) =>
+    webmake(handlerModulePath, { ignoreErrors: true, cjs: true }, (error, code) => {
+      error ? reject(error) : resolve(code);
+    })
+  );
+  if (lambdaHandlerMode !== 'dev') {
+    const minifyResult = Terser.minify(bundleCode);
+    if (minifyResult.error) throw minifyResult.error;
+    bundleCode = minifyResult.code;
+  }
+  await fse.ensureDir(path.dirname(cachedHandlerPath));
+  return fse.writeFile(cachedHandlerPath, bundleCode);
+};

--- a/lib/resolve-cached-handler-path/index.js
+++ b/lib/resolve-cached-handler-path/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const fse = require('fs-extra');
+const generateHandler = require('./generate');
+const resolvePath = require('./resolve-path');
+
+module.exports = async inputs => {
+  const cachedHandlerPath = resolvePath(inputs);
+  if (!(await fse.pathExists(cachedHandlerPath))) await generateHandler(inputs);
+  return cachedHandlerPath;
+};

--- a/lib/resolve-cached-handler-path/resolve-path.js
+++ b/lib/resolve-cached-handler-path/resolve-path.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const { version } = require('../../package');
+
+module.exports = ({ lambdaHandlerMode }) =>
+  path.join(
+    os.homedir(),
+    '.serverless/cache/tencent-koa',
+    version,
+    `serverless-handler${lambdaHandlerMode === 'dev' ? '-dev' : ''}.js`
+  );

--- a/package.json
+++ b/package.json
@@ -11,15 +11,29 @@
     "tencent"
   ],
   "author": "Serverless, Inc.",
+  "main": "serverless.js",
+  "dependencies": {
+    "@serverless/core": "^1.1.2",
+    "@serverless/tencent-apigateway": "^1.9.10",
+    "@serverless/tencent-scf": "^1.2.3",
+    "aws-serverless-express": "^3.3.6",
+    "ext": "^1.4.0",
+    "fs-extra": "^8.1.0",
+    "terser": "^4.4.1",
+    "type": "^2.0.0",
+    "webmake": "^1.1.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@serverless/eslint-config": "^1.2.1",
     "eslint": "^6.7.1",
     "eslint-plugin-import": "^2.18.2",
+    "essentials": "^1.1.1",
     "git-list-updated": "^1.2.1",
     "github-release-from-cc-changelog": "^2.2.0",
     "husky": "^3.1.0",
     "lint-staged": "^9.5.0",
+    "minimist": "^1.2.0",
     "prettier": "^1.19.1",
     "standard-version": "^7.0.1"
   },
@@ -28,7 +42,17 @@
     "root": true,
     "parserOptions": {
       "ecmaVersion": 2017
-    }
+    },
+    "overrides": [
+      {
+        "files": [
+          "lib/resolve-cached-handler-path/generate.js"
+        ],
+        "rules": {
+          "no-unused-expressions": "off"
+        }
+      }
+    ]
   },
   "husky": {
     "hooks": {

--- a/scripts/cache-lambda-handler.js
+++ b/scripts/cache-lambda-handler.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('essentials');
+
+const argv = require('minimist')(process.argv.slice(2), {
+  boolean: ['help'],
+  string: ['lambda-handler-mode'],
+  alias: { 'help': 'h', 'lambda-handler-mode': 'm' },
+});
+
+const usage = `Usage: ./scripts/cache-lambda-handler [-h | --help]
+Generates lambda handler bundle and saves it to user cache
+
+Options:
+
+    --lambda-handler-mode,  -m  Lambda handler mode ('dev' or 'prod', defaults to 'prod')
+    --help,                 -h  Show this message
+`;
+
+if (argv.help) {
+  process.stdout.write(usage);
+  return;
+}
+
+require('../lib/resolve-cached-handler-path/generate')({
+  lambdaHandlerMode: argv['lambda-handler-mode'],
+});

--- a/serverless.js
+++ b/serverless.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const ensureIterable = require('type/iterable/ensure');
+const ensurePlainObject = require('type/plain-object/ensure');
+const ensureString = require('type/string/ensure');
+const random = require('ext/string/random');
+const path = require('path');
+const { Component, utils } = require('@serverless/core');
+const resolveCachedHandlerPath = require('./lib/resolve-cached-handler-path');
+
+module.exports = class TencentKoa extends Component {
+  async default(inputs = {}) {
+    inputs.name =
+      ensureString(inputs.functionName, { isOptional: true }) ||
+      this.state.functionName ||
+      `KoaComponent_${random({ length: 6 })}`;
+    inputs.codeUri = ensureString(inputs.code, { isOptional: true }) || process.cwd();
+    inputs.region = ensureString(inputs.region, { default: 'ap-guangzhou' });
+    inputs.include = ensureIterable(inputs.include, { default: [], ensureItem: ensureString });
+    inputs.exclude = ensureIterable(inputs.exclude, { default: [], ensureItem: ensureString });
+    const apigatewayConf = ensurePlainObject(inputs.apigatewayConf, { default: {} });
+
+    if (!(await utils.fileExists(path.resolve(inputs.codeUri, 'app.js')))) {
+      throw new Error(`app.js not found in ${inputs.codeUri}`);
+    }
+
+    const cachedHandlerPath = await resolveCachedHandlerPath(inputs);
+    inputs.include.push(cachedHandlerPath);
+    inputs.exclude.push('.git/**', '.gitignore', '.serverless', '.DS_Store');
+
+    inputs.handler = `${path.basename(cachedHandlerPath, '.js')}.handler`;
+    inputs.runtime = 'Nodejs8.9';
+
+    const tencentCloudFunction = await this.load('@serverless/tencent-scf');
+    const tencentApiGateway = await this.load('@serverless/tencent-apigateway');
+
+    if (inputs.functionConf) {
+      inputs.timeout = inputs.functionConf.timeout || 3;
+      inputs.memorySize = inputs.functionConf.memorySize || 128;
+      if (inputs.functionConf.environment) inputs.environment = inputs.functionConf.environment;
+      if (inputs.functionConf.vpcConfig) inputs.vpcConfig = inputs.functionConf.vpcConfig;
+    }
+
+    const tencentCloudFunctionOutputs = await tencentCloudFunction(inputs);
+    const apigwParam = {
+      serviceName: inputs.serviceName,
+      description: 'Serverless Framework tencent-koa Component',
+      serviceId: inputs.serviceId,
+      region: inputs.region,
+      protocol: apigatewayConf.protocol || 'http',
+      environment: apigatewayConf.environment || 'release',
+      endpoints: [
+        {
+          path: '/',
+          method: 'ANY',
+          function: {
+            isIntegratedResponse: true,
+            functionName: tencentCloudFunctionOutputs.Name,
+          },
+        },
+      ],
+    };
+    if (apigatewayConf.usagePlan) apigwParam.endpoints[0].usagePlan = apigatewayConf.usagePlan;
+    if (apigatewayConf.auth) apigwParam.endpoints[0].auth = inputs.apigatewayConf.auth;
+
+    this.state.functionName = inputs.name;
+    await this.save();
+    const tencentApiGatewayOutputs = await tencentApiGateway(apigwParam);
+    return {
+      region: inputs.region,
+      functionName: inputs.name,
+      apiGatewayServiceId: tencentApiGatewayOutputs.serviceId,
+      url: `${tencentApiGatewayOutputs.protocol}://${tencentApiGatewayOutputs.subDomain}/${tencentApiGatewayOutputs.environment}/`,
+    };
+  }
+
+  async remove() {
+    const tencentApiGateway = await this.load('@serverless/tencent-apigateway');
+    const tencentCloudFunction = await this.load('@serverless/tencent-scf');
+
+    await tencentApiGateway.remove();
+    await tencentCloudFunction.remove();
+
+    return {};
+  }
+};


### PR DESCRIPTION
Similarly as [tencent-express](https://github.com/serverless-components/tencent-express) component relies on HTTP server mock. Still here to avoid copy/paste, I decided to rely on `aws-serverless-express` directly. _(If it'll appear that `aws-serverless-express` is not perfectly compliant with Tencent API Gateway, we will need to create a Tencent counterpart, and rely on that one instead)_

There's no need for user to install `aws-serverless-express`, as component ensures it's bundled into generated lambda handler.

Custom lambda handler is put into`serverless-handler.js` file, which is the only non-user file to be included with the lambda.

Lambda handler code by default is minified (to be minimal in size). Still for debugging needs, it could be served in not minified form, which is triggered by `lambdaHandlerMode: dev` configuration setting.

I've also ensured that auto-generated function name doesn't change across repeated deployments of same service.